### PR TITLE
宮城 ユーザーログインのみ実行 master

### DIFF
--- a/app/assets/stylesheets/modules/_products_category.scss
+++ b/app/assets/stylesheets/modules/_products_category.scss
@@ -47,14 +47,15 @@
           }
           span {
             position: absolute;
-            top: 0;
-            left: 0;
+            top: 15px;
+            left: -5px;
             .soldout-label{
               height: 224%;
               width: 110%;
-              background-color: white;
               color: red;
               font-size: 20px;
+              font-weight: bold;
+              transform:rotate(-45deg);
             }
           }
         }

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -27,8 +27,7 @@ class OrdersController < ApplicationController
       currency: 'jpy',
       )
       # 売り切れなので、productの情報をアップデートして売り切れにし、出品状態を取り下げる（exhibiting:1が出品中、0が出品停止中）
-      @product.update_attribute(:exhibiting, 0)
-      @product.update_attribute(:sold, 0)
+      @product.update_attribute(:exhibition_id, 1)
       @order = Order.new(user_id: current_user.id, product_id: @product.id, address_id: @address.id)
         if @order.save
           flash[:notice] = '購入しました。'

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,9 +1,9 @@
 class ProductsController < ApplicationController
   before_action :set_product, except: [:index, :new, :create]
   def index
-    products = Product.includes(:images).limit(3)
-    @category =products.order(created_at: :desc)
-    @brand =products.order(brand_id: :desc)
+    products = Product.includes(:images).where(exhibition_id: [1,2])
+    @category =products.order(created_at: :desc).limit(3)
+    @brand =products.order(brand_id: :desc).limit(3)
     @images = Image.all.includes(:product)
   end
 
@@ -47,7 +47,13 @@ class ProductsController < ApplicationController
 
   private
   def product_params
-    params.require(:product).permit(:name, :explain, :price, :category_id, :brand_id, :condition_id, :deliveryday_id, :prefecture_id, :burden_id, :exhibiting, images_attributes:[:image, :_destroy, :id]).merge(user_id: current_user.id)
+    params.require(:product).permit(
+                            :name, :explain, :price, 
+                            :category_id, :brand_id, :condition_id, :deliveryday_id, :prefecture_id, :burden_id,
+                            images_attributes:[:image, :_destroy, :id]
+                             ).merge(
+                              user_id: current_user.id, exhibition_id: 2
+                              )
   end
 
   def set_product

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :only_signed_in_user
 
   def show
   end
@@ -10,6 +11,14 @@ class UsersController < ApplicationController
   end
 
   def logout
+  end
+
+  private
+
+  def only_signed_in_user
+    unless user_signed_in?
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -1,0 +1,5 @@
+class Exhibition < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '売り切れ'},{id: 2, name: '出品中'},{id: 3, name: '出品停止中'}
+  ]
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -18,6 +18,7 @@ class Product < ApplicationRecord
   belongs_to_active_hash :deliveryday
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :brand
+  belongs_to_active_hash :exhibition
   has_one :order
   has_many :images, dependent: :destroy
   has_many :products

--- a/app/views/products/contents/_title.html.haml
+++ b/app/views/products/contents/_title.html.haml
@@ -12,7 +12,8 @@
         = image_tag '/images/material/logo/apple_store.png', class:'apple'
       = link_to '#' do
         = image_tag '/images/material/logo/google_play.png', class:'google'
-  = link_to '/products/new', class: "exhibition__btn" do
-    .exhibition__letter
-      出品
-    .exhibition__icon
+  -if user_signed_in?
+    = link_to '/products/new', class: "exhibition__btn" do
+      .exhibition__letter
+        出品
+      .exhibition__icon

--- a/app/views/products/contents/pickup/_brand.html.haml
+++ b/app/views/products/contents/pickup/_brand.html.haml
@@ -11,10 +11,10 @@
           = link_to product_path(product), class:"product-link" do
             .product-image-box
               = image_tag product.images[0].image.url,class:"image-size"
-              -if  product.sold == 0
+              -if  product.exhibition_id == 1
                 %span
                   .soldout-label
-                    soldout
+                    =product.exhibition.name
 
             .product-link__description
               .product-name

--- a/app/views/products/contents/pickup/_category.html.haml
+++ b/app/views/products/contents/pickup/_category.html.haml
@@ -11,10 +11,10 @@
           = link_to product_path(product), class:"product-link" do
             .product-image-box
               = image_tag product.images[0].image.url,class:"image-size"
-              -if product.sold == 0
+              -if product.exhibition_id == 1
                 %span
                   .soldout-label
-                    soldout
+                    =product.exhibition.name
             .product-link__description
               .product-name
                 = product.name

--- a/db/migrate/20200330065022_add_exhibiting_to_products.rb
+++ b/db/migrate/20200330065022_add_exhibiting_to_products.rb
@@ -1,6 +1,5 @@
 class AddExhibitingToProducts < ActiveRecord::Migration[5.2]
   def change
-    add_column :products, :exhibiting, :integer
-    add_column :products, :sold, :integer
+    add_column :products, :exhibition_id, :integer, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,8 +89,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_090015) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "exhibiting"
-    t.integer "sold"
+    t.integer "exhibition_id", null: false
     t.integer "likes_count"
     t.index ["user_id"], name: "index_products_on_user_id"
   end


### PR DESCRIPTION
### What
ログイン中のみ出品ボタンがトップページで押せる
ログインしていないユーザーが不正にマイページに跳ぼうとしたらトップページにリダイレクトする

### Why
ログインしていないユーザーは出品できないので、ロップページの出品ボタンが不必要
アドレスにuserを入力するとユーザーページに飛べるがニックネームなどの情報がないのでエラーが出る。そのエラーが出るのを防ぐため