### PR TITLE
宮城 マイページ情報編集パンクズ master

### DIFF
--- a/app/assets/stylesheets/modules/_users_right_content.scss
+++ b/app/assets/stylesheets/modules/_users_right_content.scss
@@ -63,6 +63,9 @@
   width: 100%;
   min-height: 300px;
   display: none;
+  .mypage_product{
+    padding-left: 10px;
+  }
   p {
     font-size: 14px;
     letter-spacing: 1px;

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,10 +1,12 @@
 .sign
   .sign-header
     = link_to image_tag("logo.svg"), root_path
+  - breadcrumb :userAddress
+  = render "layouts/breadcrumbs"
   .sign-main
     = form_with model: @address, local: true do |f|
       .sign-main-box.sign-main-box-last
-        %h1.sign-main-box__title お届け先変更
+        %h1.sign-main-box__title 発送元・お届け住所変更
         .field
           = f.label :送付先氏名（全角）, class: "field__text"
           %p.field__text-constraint 必須

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -29,4 +29,33 @@
           %p.field__text-constraint 必須
           = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード", class: "field__input"
           = render partial: '/errors/error-messages', locals: {user: @user, column: "password_confirmation"}
+
+
+      .sign-main-box.sign-main-box-last
+        %h1.sign-main-box__title 本人確認情報
+        .field
+          = f.label :お名前（全角）, class: "field__text"
+          %p.field__text-constraint 必須
+          .field-box
+            = f.text_field :last_name, placeholder: "性", class: "field-box__input"
+            = f.text_field :first_name, placeholder: "名", class: "field-box__input"
+          = render partial: '/errors/error-messages', locals: {user: @user, column: "last_name"}
+          = render partial: '/errors/error-messages', locals: {user: @user, column: "first_name"}
+
+        .field
+          = f.label :お名前かな（全角）, class: "field__text"
+          %p.field__text-constraint 必須
+          .field-box
+            = f.text_field :last_name_kana, placeholder: "せい", class: "field-box__input"
+            = f.text_field :first_name_kana, placeholder: "めい", class: "field-box__input"
+          = render partial: '/errors/error-messages', locals: {user: @user, column: "last_name_kana"}
+          = render partial: '/errors/error-messages', locals: {user: @user, column: "first_name_kana"}
+
+        .field
+          = f.label :生年月日, class: "field__text"
+          %p.field__text-constraint 必須
+          .field__birthday
+            != sprintf(f.date_select(:birthday, use_month_numbers: true,start_year: Time.now.year, end_year: 1910, prompt:"--", date_separator:'%s'),'年','月')+'日'
+          = render partial: '/errors/error-messages', locals: {user: @user, column: "birthday"}
+
       = f.submit "更新する", class: "actions"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,10 +1,13 @@
 .sign
   .sign-header
     = link_to image_tag("logo.svg"), root_path
+  - breadcrumb :userMailPassword
+  = render "layouts/breadcrumbs"
+
   .sign-main
     = form_with model: @user, url: user_registration_path, local: true do |f|
       .sign-main-box
-        %h1.sign-main-box__title ユーザー情報編集
+        %h1.sign-main-box__title メール/パスワード編集
         .field
           = f.label :ニックネーム, class: "field__text"
           %p.field__text-constraint 必須
@@ -26,33 +29,4 @@
           %p.field__text-constraint 必須
           = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワード", class: "field__input"
           = render partial: '/errors/error-messages', locals: {user: @user, column: "password_confirmation"}
-
-
-      .sign-main-box.sign-main-box-last
-        %h1.sign-main-box__title 本人確認情報
-        .field
-          = f.label :お名前（全角）, class: "field__text"
-          %p.field__text-constraint 必須
-          .field-box
-            = f.text_field :last_name, placeholder: "性", class: "field-box__input"
-            = f.text_field :first_name, placeholder: "名", class: "field-box__input"
-          = render partial: '/errors/error-messages', locals: {user: @user, column: "last_name"}
-          = render partial: '/errors/error-messages', locals: {user: @user, column: "first_name"}
-
-        .field
-          = f.label :お名前かな（全角）, class: "field__text"
-          %p.field__text-constraint 必須
-          .field-box
-            = f.text_field :last_name_kana, placeholder: "せい", class: "field-box__input"
-            = f.text_field :first_name_kana, placeholder: "めい", class: "field-box__input"
-          = render partial: '/errors/error-messages', locals: {user: @user, column: "last_name_kana"}
-          = render partial: '/errors/error-messages', locals: {user: @user, column: "first_name_kana"}
-
-        .field
-          = f.label :生年月日, class: "field__text"
-          %p.field__text-constraint 必須
-          .field__birthday
-            != sprintf(f.date_select(:birthday, use_month_numbers: true,start_year: Time.now.year, end_year: 1910, prompt:"--", date_separator:'%s'),'年','月')+'日'
-          = render partial: '/errors/error-messages', locals: {user: @user, column: "birthday"}
-
       = f.submit "更新する", class: "actions"

--- a/app/views/users/modules/_show_left_content.html.haml
+++ b/app/views/users/modules/_show_left_content.html.haml
@@ -25,6 +25,11 @@
   .table_title
     設定
   %table      
+    %tr  
+      %td{id:"mypage-td"}
+        =link_to cards_path ,class:"table-link" do
+          お支払い方法/クレジットカード登録
+          %i{class:"fas fa-chevron-right",id:"mypage-arrow"}
     %tr
       %td{id:"mypage-td"}
         = link_to edit_address_path(@addresses),class:"table-link" do
@@ -32,13 +37,8 @@
           %i{class:"fas fa-chevron-right",id:"mypage-arrow"}
     %tr  
       %td{id:"mypage-td"}
-        =link_to cards_path ,class:"table-link" do
-          お支払い方法
-          %i{class:"fas fa-chevron-right",id:"mypage-arrow"}
-    %tr  
-      %td{id:"mypage-td"}
         =link_to edit_user_registration_path ,class:"table-link" do
-          メール/パスワード
+          登録情報編集
           %i{class:"fas fa-chevron-right",id:"mypage-arrow"}
     %tr  
       %td{id:"mypage-td"}

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -33,7 +33,7 @@ crumb :userAddress do
 end
 
 crumb :userMailPassword do
-  link "メール/パスワード編集", edit_user_registration_path
+  link "登録情報編集", edit_user_registration_path
   parent :userShow
 end
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -27,6 +27,16 @@ crumb :userSolded do
   parent :userShow
 end
 
+crumb :userAddress do
+  link "発送元・お届け住所変更", edit_address_path
+  parent :userShow
+end
+
+crumb :userMailPassword do
+  link "メール/パスワード編集", edit_user_registration_path
+  parent :userShow
+end
+
 crumb :productShow do
   link "#{Product.find(params[:id]).name}" , product_path(params[:id])
   parent :root


### PR DESCRIPTION
what

マイページにおける住所変更、パスワード/メールアドレス変更でパンくずリストの追加
表示文言の統一
マイぺージの左側の表示の名前の変更と並び替え

お支払い方法→お支払い方法/クレジットカード登録

why

マイページにおける住所変更、パスワード/メールアドレス変更は
新規登録画面と酷似しているため、今はどこのページにいるのかを明示する
表示を統一にして見やすくする。

https://gyazo.com/ea5f79047835f92479ad294e86d03e12